### PR TITLE
Update compat bound with Dagger.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-Dagger = "0.9"
+Dagger = "0.9 - 0.10"
 Requires = "1"
 julia = "1"
 


### PR DESCRIPTION
Had to downgrade to Dagger v0.9.0 to use DaggerGPU.jl but presumably it's compatible with Dagger v0.10.0 which was released recently.