### PR TITLE
Initial support for in-place operations with unified memory

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -99,7 +99,7 @@ end
 
 processor(::Val{:Metal}) = MtlArrayDeviceProc
 cancompute(::Val{:Metal}) = length(Metal.devices()) >= 1
-kernel_backend(::MtlArrayDeviceProc) = MtlArrayDeviceProc
+kernel_backend(proc::MtlArrayDeviceProc) = _get_metal_device(proc)
 
 for dev in Metal.devices()
     Dagger.add_processor_callback!("metal_device_$(dev.registryID)") do

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -3,10 +3,97 @@ import .Metal: MtlArray, MtlDevice
 
 struct MtlArrayDeviceProc <: Dagger.Processor
     owner::Int
-    device::MtlDevice
+    device_id::UInt64
 end
 
-@gpuproc(MtlArrayDeviceProc, MtlArray)
+# Assume that we can run anything.
+Dagger.iscompatible_func(proc::MtlArrayDeviceProc, opts, f) = true
+Dagger.iscompatible_arg(proc::MtlArrayDeviceProc, opts, x) = true
+
+# CPUs shouldn't process our array type.
+Dagger.iscompatible_arg(proc::Dagger.ThreadProc, opts, x::MtlArray) = false
+
+function Dagger.move(from_proc::OSProc, to_proc::MtlArrayDeviceProc, x::Chunk)
+    from_pid = from_proc.pid
+    to_pid = Dagger.get_parent(to_proc).pid
+    @assert myid() == to_pid
+
+    return remotecall_fetch(from_pid, x) do x
+        array = poolget(x.handle)
+
+        # If we have unified memory, we can try casting the `Array` to
+        # `MtlArray`.
+        device = _get_metal_device(to_proc)
+
+        if (device !== nothing) && device.hasUnifiedMemory
+            mtlarray = _cast_array_to_mtlarray(x, device)
+            mtlarray !== nothing && return mtlarray
+        end
+
+        return adapt(MtlArray, array)
+    end
+end
+
+function Dagger.move(from_proc::MtlArrayDeviceProc, to_proc::OSProc, x::Chunk)
+    from_pid = Dagger.get_parent(from_proc).pid
+    to_pid = to_proc.pid
+    @assert myid() == to_pid
+
+    return remotecall_fetch(from_pid, x) do x
+        mtlarray = poolget(x.handle)
+
+        # If we have unified memory, we can just cast the `MtlArray` to an
+        # `Array`.
+        device = _get_metal_device(from_proc)
+
+        if (device !== nothing) && device.hasUnifiedMemory
+            T = eltype(mtlarray)
+            return unsafe_wrap(Array{T}, mtlarray, size(mtlarray))
+        else
+            return adapt(Array, mtlarray)
+        end
+    end
+end
+
+function Dagger.move(
+    from_proc::OSProc,
+    to_proc::MtlArrayDeviceProc,
+    x::Array{T, N}
+) where {T, N}
+    # If we have unified memory, we can try casting the `Array` to `MtlArray`.
+    device = _get_metal_device(to_proc)
+
+    if (device !== nothing) && device.hasUnifiedMemory
+        marray = _cast_array_to_mtlarray(x, device)
+        marray !== nothing && return marray
+    end
+
+    return adapt(MtlArray, x)
+end
+
+function Dagger.move(from_proc::OSProc, to_proc::MtlArrayDeviceProc, x)
+    adapt(MtlArray, x)
+end
+
+function Dagger.move(
+    from_proc::MtlArrayDeviceProc,
+    to_proc::OSProc,
+    x::Array{T, N}
+) where {T, N}
+    # If we have unified memory, we can just cast the `MtlArray` to an `Array`.
+    device = _get_metal_device(from_proc)
+
+    if (device !== nothing) && device.hasUnifiedMemory
+        return unsafe_wrap(Array{T}, x, size(x))
+    else
+        return adapt(Array, x)
+    end
+end
+
+function Dagger.move(from_proc::MtlArrayDeviceProc, to_proc::OSProc, x)
+    adapt(Array, x)
+end
+
 Dagger.get_parent(proc::MtlArrayDeviceProc) = Dagger.OSProc(proc.owner)
 
 function Dagger.execute!(proc::MtlArrayDeviceProc, func, args...)
@@ -30,15 +117,58 @@ function Dagger.execute!(proc::MtlArrayDeviceProc, func, args...)
 end
 
 function Base.show(io::IO, proc::MtlArrayDeviceProc)
-    print(io, "MtlArrayDeviceProc on worker $(proc.owner), device ($(proc.device.name))")
+    print(io, "MtlArrayDeviceProc on worker $(proc.owner), device ($(proc.device_id))")
 end
 
 processor(::Val{:Metal}) = MtlArrayDeviceProc
 cancompute(::Val{:Metal}) = length(Metal.devices()) >= 1
-kernel_backend(::MtlArrayDeviceProc) = Metal.current_device()
+kernel_backend(::MtlArrayDeviceProc) = MtlArrayDeviceProc
 
 for dev in Metal.devices()
     Dagger.add_processor_callback!("metal_device_$(dev.registryID)") do
-        MtlArrayDeviceProc(Distributed.myid(), Metal.current_device())
+        MtlArrayDeviceProc(Distributed.myid(), dev.registryID)
+    end
+end
+
+################################################################################
+#                              Private functions
+################################################################################
+
+# Try casting the array `x` to an `MtlArray`. If the casting is not possible,
+# return `nothing`.
+function _cast_array_to_mtlarray(x::Array{T,N}, device::MtlDevice) where {T,N}
+    # Try creating the buffer without copying.
+    dims = size(x)
+    nbytes_array = prod(dims) * sizeof(T)
+    pagesize = ccall(:getpagesize, Cint, ())
+    num_pages = div(nbytes_array, pagesize, RoundUp)
+    nbytes = num_pages * pagesize
+
+    pbuf = Metal.MTL.mtDeviceNewBufferWithBytesNoCopy(
+        device,
+        pointer(x),
+        nbytes,
+        Metal.Shared | Metal.MTL.DefaultTracking | Metal.MTL.DefaultCPUCache
+    )
+
+    if pbuf != C_NULL
+        buf = MtlBuffer(pbuf)
+        marray = MtlArray{T,N}(buf, dims)
+        return marray
+    end
+
+    # If we reached here, the conversion was not possible.
+    return nothing
+end
+
+# Return the Metal device handler given the ID recorded in `proc`.
+function _get_metal_device(proc::MtlArrayDeviceProc)
+    devices = Metal.devices()
+    id = findfirst(dev -> dev.registryID == proc.device_id, devices)
+
+    if devices === nothing
+        return nothing
+    else
+        return devices[id]
     end
 end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -37,8 +37,8 @@ processor(::Val{:Metal}) = MtlArrayDeviceProc
 cancompute(::Val{:Metal}) = length(Metal.devices()) >= 1
 kernel_backend(::MtlArrayDeviceProc) = Metal.current_device()
 
-if length(Metal.devices()) >= 1
-    Dagger.add_processor_callback!("metal_device") do
+for dev in Metal.devices()
+    Dagger.add_processor_callback!("metal_device_$(dev.registryID)") do
         MtlArrayDeviceProc(Distributed.myid(), Metal.current_device())
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
         A
     end
 
-    # Create a function to perform and in-place operation.
+    # Create a function to perform an in-place operation.
     function addarray!(x)
         x .= x .+ 1.0f0
     end
@@ -142,13 +142,8 @@ end
             array[2, 1] = 3
             array[2, 2] = 4
 
-            # Here, we must only have one worker. We want to test the in-place
-            # memory computation and the memory is not shared among different
-            # workers.
-            rmprocs(workers())
-
-            # Perform the computation.
-            t = Dagger.@spawn proclist = [metalproc] addarray!(array)
+            # Perform the computation only on a local `MtlArrayDeviceProc`
+            t = Dagger.@spawn single=myid() proclist = [metalproc] addarray!(array)
 
             # Fetch and check the results.
             ret = fetch(t)


### PR DESCRIPTION
Hi!

This PR contains my first attempt to implement in-place operations when unified memory is available.

With this PR, the following operation:

```julia
function addarray!(x)
    x .= x .+ 1.0f0
end

Dager.@sync Dager.@spawn proclist = [metalproc] addarray!(array)
```

will add 1 to every element in `array` using GPU in the same memory as `array`, avoiding allocations. However, this can only happen if `array` is page-aligned. The code here already verifies the required conditions and fall-back to the usual operation if not.